### PR TITLE
Introduce generics, remove explicit downcastings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.idea
+*.iml

--- a/src/main/java/barbara/FactoryEmployer.java
+++ b/src/main/java/barbara/FactoryEmployer.java
@@ -1,34 +1,33 @@
 package barbara;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 import barbara.abstractFactory.AbstractDataProvider;
 import barbara.abstractFactory.AbstractDataSerializer;
 import barbara.abstractFactory.AbstractFactory;
 import barbara.blueFactory.BlueFactory;
 import barbara.redFactory.RedFactory;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class FactoryEmployer {
+
     public static void main(String[] args) {
         FactoryEmployer factoryEmployer = new FactoryEmployer();
-        List<AbstractFactory> factories = Arrays.asList(new BlueFactory(), new RedFactory());
-        for (AbstractFactory factory : factories) {
-            System.out.printf(
-                    "%-35s -> %s%n",
-                    factory.getClass().getCanonicalName(),
-                    factoryEmployer.prepareDataAndSerialize(factory)
-            );
-        }
+        List<AbstractFactory<?>> factories = List.of(new BlueFactory(), new RedFactory());
+        factories.forEach(factory -> System.out.printf(
+                "%-35s -> %s%n",
+                factory.getClass().getCanonicalName(),
+                factoryEmployer.prepareDataAndSerialize(factory)
+        ));
     }
 
-    private String prepareDataAndSerialize(AbstractFactory factory) {
-        AbstractDataHolder dataHolder = factory.createDataHolder();
-        AbstractDataProvider dataProvider = factory.createDataProvider();
+    public <T extends DataHolder> String prepareDataAndSerialize(AbstractFactory<T> factory) {
+        T dataHolder = factory.createDataHolder();
+        AbstractDataProvider<T> dataProvider = factory.createDataProvider();
         dataProvider.applyDataToDataHolder(dataHolder);
-        AbstractDataSerializer serializer = factory.createDataSerializer();
+        AbstractDataSerializer<T> serializer = factory.createDataSerializer();
 
         return serializer.serialize(dataHolder);
     }
+
 }

--- a/src/main/java/barbara/abstractFactory/AbstractDataProvider.java
+++ b/src/main/java/barbara/abstractFactory/AbstractDataProvider.java
@@ -1,5 +1,7 @@
 package barbara.abstractFactory;
 
-public abstract class AbstractDataProvider {
-    abstract public void applyDataToDataHolder(AbstractDataHolder holder);
+public abstract class AbstractDataProvider<T extends DataHolder> {
+
+    public abstract void applyDataToDataHolder(T holder);
+
 }

--- a/src/main/java/barbara/abstractFactory/AbstractDataSerializer.java
+++ b/src/main/java/barbara/abstractFactory/AbstractDataSerializer.java
@@ -1,5 +1,7 @@
 package barbara.abstractFactory;
 
-public abstract class AbstractDataSerializer {
-    public abstract String serialize(AbstractDataHolder holder);
+public abstract class AbstractDataSerializer<T extends DataHolder> {
+
+    public abstract String serialize(T holder);
+
 }

--- a/src/main/java/barbara/abstractFactory/AbstractFactory.java
+++ b/src/main/java/barbara/abstractFactory/AbstractFactory.java
@@ -1,9 +1,11 @@
 package barbara.abstractFactory;
 
-abstract public class AbstractFactory {
-    abstract public AbstractDataProvider createDataProvider();
+public abstract class AbstractFactory<T extends DataHolder> {
 
-    abstract public AbstractDataHolder createDataHolder();
+    public abstract AbstractDataProvider<T> createDataProvider();
 
-    abstract public AbstractDataSerializer createDataSerializer();
+    public abstract T createDataHolder();
+
+    public abstract AbstractDataSerializer<T> createDataSerializer();
+
 }

--- a/src/main/java/barbara/abstractFactory/DataHolder.java
+++ b/src/main/java/barbara/abstractFactory/DataHolder.java
@@ -1,4 +1,5 @@
 package barbara.abstractFactory;
 
-public class AbstractDataHolder {
+public interface DataHolder {
+
 }

--- a/src/main/java/barbara/blueFactory/BlueDataHolder.java
+++ b/src/main/java/barbara/blueFactory/BlueDataHolder.java
@@ -1,8 +1,10 @@
 package barbara.blueFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 
-public class BlueDataHolder extends AbstractDataHolder {
+public class BlueDataHolder implements DataHolder {
+
     public String blueName;
     public int blueAge;
+
 }

--- a/src/main/java/barbara/blueFactory/BlueDataProvider.java
+++ b/src/main/java/barbara/blueFactory/BlueDataProvider.java
@@ -1,13 +1,13 @@
 package barbara.blueFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
 import barbara.abstractFactory.AbstractDataProvider;
 
-public class BlueDataProvider extends AbstractDataProvider {
+public class BlueDataProvider extends AbstractDataProvider<BlueDataHolder> {
+
     @Override
-    public void applyDataToDataHolder(AbstractDataHolder holder) {
-        BlueDataHolder concreteDataHolder = (BlueDataHolder) holder;
-        concreteDataHolder.blueName = "Lord of the Blue";
-        concreteDataHolder.blueAge = 42;
+    public void applyDataToDataHolder(BlueDataHolder holder) {
+        holder.blueName = "Lord of the Blue";
+        holder.blueAge = 42;
     }
+
 }

--- a/src/main/java/barbara/blueFactory/BlueDataSerializer.java
+++ b/src/main/java/barbara/blueFactory/BlueDataSerializer.java
@@ -1,13 +1,13 @@
 package barbara.blueFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 import barbara.abstractFactory.AbstractDataSerializer;
 
-public class BlueDataSerializer extends AbstractDataSerializer {
-    @Override
-    public String serialize(AbstractDataHolder holder) {
-        BlueDataHolder concreteDataHolder = (BlueDataHolder) holder;
+public class BlueDataSerializer extends AbstractDataSerializer<BlueDataHolder> {
 
-        return String.format("name: %s / age: %d", concreteDataHolder.blueName, concreteDataHolder.blueAge);
+    @Override
+    public String serialize(BlueDataHolder holder) {
+        return "name: %s / age: %d".formatted(holder.blueName, holder.blueAge);
     }
+
 }

--- a/src/main/java/barbara/blueFactory/BlueFactory.java
+++ b/src/main/java/barbara/blueFactory/BlueFactory.java
@@ -1,23 +1,25 @@
 package barbara.blueFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 import barbara.abstractFactory.AbstractDataProvider;
 import barbara.abstractFactory.AbstractDataSerializer;
 import barbara.abstractFactory.AbstractFactory;
 
-public class BlueFactory extends AbstractFactory {
+public class BlueFactory extends AbstractFactory<BlueDataHolder> {
+
     @Override
-    public AbstractDataProvider createDataProvider() {
+    public AbstractDataProvider<BlueDataHolder> createDataProvider() {
         return new BlueDataProvider();
     }
 
     @Override
-    public AbstractDataHolder createDataHolder() {
+    public BlueDataHolder createDataHolder() {
         return new BlueDataHolder();
     }
 
     @Override
-    public AbstractDataSerializer createDataSerializer() {
+    public AbstractDataSerializer<BlueDataHolder> createDataSerializer() {
         return new BlueDataSerializer();
     }
+
 }

--- a/src/main/java/barbara/redFactory/RedDataHolder.java
+++ b/src/main/java/barbara/redFactory/RedDataHolder.java
@@ -1,8 +1,8 @@
 package barbara.redFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 
-public class RedDataHolder extends AbstractDataHolder {
+public class RedDataHolder implements DataHolder {
     public String favoriteDish;
     public int size;
 }

--- a/src/main/java/barbara/redFactory/RedDataProvider.java
+++ b/src/main/java/barbara/redFactory/RedDataProvider.java
@@ -1,13 +1,14 @@
 package barbara.redFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 import barbara.abstractFactory.AbstractDataProvider;
+import barbara.blueFactory.BlueDataHolder;
 
-public class RedDataProvider extends AbstractDataProvider {
+public class RedDataProvider extends AbstractDataProvider<RedDataHolder> {
+
     @Override
-    public void applyDataToDataHolder(AbstractDataHolder holder) {
-        RedDataHolder concreteDataHolder = (RedDataHolder) holder;
-        concreteDataHolder.favoriteDish = "Pizza";
-        concreteDataHolder.size = 32;
+    public void applyDataToDataHolder(RedDataHolder holder) {
+        holder.favoriteDish = "Pizza";
+        holder.size = 32;
     }
 }

--- a/src/main/java/barbara/redFactory/RedDataSerializer.java
+++ b/src/main/java/barbara/redFactory/RedDataSerializer.java
@@ -1,12 +1,10 @@
 package barbara.redFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
 import barbara.abstractFactory.AbstractDataSerializer;
 
-public class RedDataSerializer extends AbstractDataSerializer {
+public class RedDataSerializer extends AbstractDataSerializer<RedDataHolder> {
     @Override
-    public String serialize(AbstractDataHolder holder) {
-        RedDataHolder concreteDataHolder = (RedDataHolder) holder;
-        return String.format("Favorite dish: %s / size: %d", concreteDataHolder.favoriteDish, concreteDataHolder.size);
+    public String serialize(RedDataHolder holder) {
+        return "Favorite dish: %s / size: %d".formatted(holder.favoriteDish, holder.size);
     }
 }

--- a/src/main/java/barbara/redFactory/RedFactory.java
+++ b/src/main/java/barbara/redFactory/RedFactory.java
@@ -1,23 +1,25 @@
 package barbara.redFactory;
 
-import barbara.abstractFactory.AbstractDataHolder;
+import barbara.abstractFactory.DataHolder;
 import barbara.abstractFactory.AbstractDataProvider;
 import barbara.abstractFactory.AbstractDataSerializer;
 import barbara.abstractFactory.AbstractFactory;
 
-public class RedFactory extends AbstractFactory {
+public class RedFactory extends AbstractFactory<RedDataHolder> {
+
     @Override
-    public AbstractDataProvider createDataProvider() {
+    public AbstractDataProvider<RedDataHolder> createDataProvider() {
         return new RedDataProvider();
     }
 
     @Override
-    public AbstractDataHolder createDataHolder() {
+    public RedDataHolder createDataHolder() {
         return new RedDataHolder();
     }
 
     @Override
-    public AbstractDataSerializer createDataSerializer() {
+    public AbstractDataSerializer<RedDataHolder> createDataSerializer() {
         return new RedDataSerializer();
     }
+
 }


### PR DESCRIPTION
You have been almost there! For such needs, we use [generics](https://en.wikipedia.org/wiki/Generics_in_Java) to achieve compile-time type safety while avoiding unnecessary castings and related warnings, even if it brings problems like [type-erasure](https://en.wikipedia.org/wiki/Type_erasure) it works nicely in Java.

Even if it is not natively supported, generics are also achievable in modern PHP codebases using tools like Psalm or PHPStan  like demonstrated in [this article](https://dev.to/jszutkowski/how-to-start-using-generic-types-in-php-2f1k), PHPStorm also has capability to understand such annotations to hint/warn developer during development.

I hope it gives an idea.